### PR TITLE
Updated the release note and the migration experience.

### DIFF
--- a/Android/app/build.gradle
+++ b/Android/app/build.gradle
@@ -34,7 +34,7 @@ android {
         minSdkVersion 21
         targetSdkVersion 25
         versionCode 1
-        versionName "2017.9.1.12" // Do NOT change this line manually. It is changed automatically everytime the Windows app is built.
+        versionName "2017.9.1.26" // Do NOT change this line manually. It is changed automatically everytime the Windows app is built.
         // Do NOT change this line manually. It is changed automatically everytime the Windows app is built.
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
         jackOptions {

--- a/ClipboardZanager/Sources/ClipboardZanager/Assets/news/news.en.json
+++ b/ClipboardZanager/Sources/ClipboardZanager/Assets/news/news.en.json
@@ -2,7 +2,12 @@
   {
     "Icon": "\uEB9F",
     "Title": "Search bar improved",
-    "Description": "You can now filter your the pictures."
+    "Description": "You can now filter the pictures."
+  },
+  {
+    "Icon": "\uE2AC",
+    "Title": "Stability improved",
+    "Description": "Fixed five issues. More information on GitHub."
   },
   {
     "Icon": "\uE1F5",

--- a/ClipboardZanager/Sources/ClipboardZanager/Assets/news/news.fr.json
+++ b/ClipboardZanager/Sources/ClipboardZanager/Assets/news/news.fr.json
@@ -5,6 +5,11 @@
     "Description": "Vous pouvez à présent filtrer les images."
   },
   {
+    "Icon": "\uE2AC",
+    "Title": "Stabilité améliorée",
+    "Description": "Cinq problèmes corrigés. Plus d'informations sur GitHub."
+  },
+  {
     "Icon": "\uE1F5",
     "Title": "Version 2017.8.22.1",
     "Description": ""

--- a/ClipboardZanager/Sources/ClipboardZanager/Properties/AssemblyInfo.cs
+++ b/ClipboardZanager/Sources/ClipboardZanager/Properties/AssemblyInfo.cs
@@ -55,8 +55,8 @@ using System.Windows;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2017.9.1.12")]
-[assembly: AssemblyFileVersion("2017.9.1.12")]
+[assembly: AssemblyVersion("2017.9.1.26")]
+[assembly: AssemblyFileVersion("2017.9.1.26")]
 
 [assembly: InternalsVisibleTo("ClipboardZanager.Tests")]
 

--- a/ClipboardZanager/Sources/ClipboardZanager/ViewModels/FirstStartWindowViewModel.cs
+++ b/ClipboardZanager/Sources/ClipboardZanager/ViewModels/FirstStartWindowViewModel.cs
@@ -105,6 +105,11 @@ namespace ClipboardZanager.ViewModels
             }
         }
 
+        /// <summary>
+        /// Gets a value that defines whether a migration is required. It usually means that the current instance is the first start after an update.
+        /// </summary>
+        public bool IsMigrationRequired { get; }
+
         #endregion 
 
         #region Constructors
@@ -118,9 +123,14 @@ namespace ClipboardZanager.ViewModels
 
             _settingProvider = new ServiceSettingProvider();
 
+            IsMigrationRequired = !string.IsNullOrWhiteSpace(Settings.Default.CurrentVersion) && Settings.Default.DataMigrationRequired;
             News = new ObservableCollection<SoftwareNewItem>();
             LoadNews();
-            DetectPasswordsManager();
+
+            if (!IsMigrationRequired)
+            {
+                DetectPasswordsManager();
+            }
         }
 
         #endregion

--- a/ClipboardZanager/Sources/ClipboardZanager/Views/FirstStartWindow.xaml
+++ b/ClipboardZanager/Sources/ClipboardZanager/Views/FirstStartWindow.xaml
@@ -23,6 +23,7 @@
         AutomationProperties.HelpText="{Binding Language.FirstStartWindow.WindowAutomationName}">
     <controls:BlurredWindow.Resources>
         <converters:ActiveColorSetToSolidColorBrushConverter x:Key="ActiveColorSetToSolidColorBrushConverter" ColorName="SystemAccent"/>
+        <converters:BooleanToVisibilityConverter x:Key="InvertedBooleanToVisibilityConverter" IsInverted="True" />
         <Storyboard x:Key="TutorialStoryboard" RepeatBehavior="Forever">
             <DoubleAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Opacity)" Storyboard.TargetName="grid">
                 <EasingDoubleKeyFrame KeyTime="0" Value="0"/>
@@ -250,7 +251,7 @@
         </Grid>
         <Grid Grid.Row="1">
             <controls:FlipView x:Name="FlipView" SelectedIndex="0">
-                <Grid>
+                <Grid x:Name="LanguageTab">
                     <TextBlock Text="{Binding Language.FirstStartWindow.Welcome_Title}" HorizontalAlignment="Center" VerticalAlignment="Top" FontSize="32" TextWrapping="Wrap" Foreground="{DynamicResource ForegroundBrush}" FontFamily="Segoe UI Light" Focusable="{Binding IsScreenReaderRunning}"/>
                     <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" VerticalAlignment="Center">
                         <TextBlock Text="{Binding Language.SettingsGeneralUserControl.Language}" VerticalAlignment="Center"/>
@@ -300,7 +301,7 @@
                         </ItemsControl>
                     </ScrollViewer>
                 </Grid>
-                <Grid>
+                <Grid x:Name="IgnoredAppTab">
                     <TextBlock Text="{Binding Language.FirstStartWindow.Security_Title}" HorizontalAlignment="Center" VerticalAlignment="Top" FontSize="32" TextWrapping="Wrap" Foreground="{DynamicResource ForegroundBrush}" FontFamily="Segoe UI Light" Focusable="{Binding IsScreenReaderRunning}"/>
                     <StackPanel Orientation="Vertical" HorizontalAlignment="Center" VerticalAlignment="Center" Width="500">
                         <TextBlock Text="{Binding Language.FirstStartWindow.Security_Description}" VerticalAlignment="Center" TextWrapping="Wrap" Focusable="{Binding IsScreenReaderRunning}"/>
@@ -367,14 +368,14 @@
                         </StackPanel>
                     </StackPanel>
                 </Grid>
-                <Grid>
+                <Grid x:Name="SynchronizationTab">
                     <TextBlock Text="{Binding Language.FirstStartWindow.Synchronization_Title}" HorizontalAlignment="Center" VerticalAlignment="Top" FontSize="32" TextWrapping="Wrap" Foreground="{DynamicResource ForegroundBrush}" FontFamily="Segoe UI Light" Focusable="{Binding IsScreenReaderRunning}"/>
                     <StackPanel Orientation="Vertical" HorizontalAlignment="Center" VerticalAlignment="Center" Width="500">
                         <TextBlock Text="{Binding Language.FirstStartWindow.Synchronization_Description}" VerticalAlignment="Center" TextWrapping="Wrap" Focusable="{Binding IsScreenReaderRunning}"/>
                         <Image Source="/ClipboardZanager;component/Assets/access_settings.jpg" Width="350" Margin="0,20,0,0"/>
                     </StackPanel>
                 </Grid>
-                <Grid>
+                <Grid x:Name="TutorialTab">
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto"/>
                         <RowDefinition Height="1*"/>
@@ -447,7 +448,7 @@
                     </Button>
                 </Grid>
             </controls:FlipView>
-            <controls:FlipViewIndicator FlipView="{Binding ElementName=FlipView}" VerticalAlignment="Bottom" HorizontalAlignment="Center" Margin="0,0,0,20"/>
+            <controls:FlipViewIndicator FlipView="{Binding ElementName=FlipView}" Visibility="{Binding IsMigrationRequired, Converter={StaticResource InvertedBooleanToVisibilityConverter}}" VerticalAlignment="Bottom" HorizontalAlignment="Center" Margin="0,0,0,20"/>
             <StackPanel VerticalAlignment="Bottom">
                 <TextBlock Text="{Binding MigrationStatus}" FontSize="12" Margin="20,0,17,2" TextTrimming="CharacterEllipsis"/>
                 <ProgressBar Value="{Binding MigrationProgress}" Foreground="White" BorderBrush="{x:Null}" Background="{x:Null}" Height="5"/>

--- a/ClipboardZanager/Sources/ClipboardZanager/Views/FirstStartWindow.xaml.cs
+++ b/ClipboardZanager/Sources/ClipboardZanager/Views/FirstStartWindow.xaml.cs
@@ -1,5 +1,6 @@
 ﻿using System.Windows.Input;
 using ClipboardZanager.ComponentModel.UI.Controls;
+using ClipboardZanager.ViewModels;
 
 namespace ClipboardZanager.Views
 {
@@ -11,6 +12,15 @@ namespace ClipboardZanager.Views
         public FirstStartWindow()
         {
             InitializeComponent();
+
+            if (((FirstStartWindowViewModel)DataContext).IsMigrationRequired)
+            {
+                FlipView.Items.Remove(LanguageTab);
+                FlipView.Items.Remove(IgnoredAppTab);
+                FlipView.Items.Remove(SynchronizationTab);
+                FlipView.Items.Remove(TutorialTab);
+                FlipView.SelectedIndex = 0;
+            }
         }
 
         private void DragZoneGrid_OnMouseLeftButtonDown(object sender, MouseButtonEventArgs e)


### PR DESCRIPTION
* When updating the app, the First Start Window experience is now concatenated to only the release note. Users don't have to choose the language and see the tutorial anymore after an update.
* The release note has been updated.