### PR TITLE
Disable passwords and credit cards sync by default

### DIFF
--- a/ClipboardZanager/Sources/ClipboardZanager.Core.Desktop/Services/DataService.cs
+++ b/ClipboardZanager/Sources/ClipboardZanager.Core.Desktop/Services/DataService.cs
@@ -294,6 +294,11 @@ namespace ClipboardZanager.Core.Desktop.Services
             Requires.NotNull(identifiers, nameof(identifiers));
             Requires.NotNull(foregroundWindow, nameof(foregroundWindow));
 
+            var shouldSynchronize = true;
+            
+            if (_settingProvider.GetSetting<bool>("DisablePasswordAndCreditCardSync"))
+                shouldSynchronize = !(isPassword || isCreditCard);
+
             var entry = new DataEntry
             {
                 Identifier = GenerateNewGuid(),
@@ -302,7 +307,7 @@ namespace ClipboardZanager.Core.Desktop.Services
                 Date = new DateTime(e.Time),
                 IsCut = e.IsCut,
                 IsFavorite = false,
-                CanSynchronize = true,
+                CanSynchronize = shouldSynchronize,
                 IconIsFromWindowStore = foregroundWindow.IsWindowsStoreApp,
                 DataIdentifiers = identifiers
             };

--- a/ClipboardZanager/Sources/ClipboardZanager/ComponentModel/Services/ServiceSettingProvider.cs
+++ b/ClipboardZanager/Sources/ClipboardZanager/ComponentModel/Services/ServiceSettingProvider.cs
@@ -76,6 +76,10 @@ namespace ClipboardZanager.ComponentModel.Services
                     value = Settings.Default.SynchronizationInterval;
                     break;
 
+                case "DisablePasswordAndCreditCardSync":
+                    value = Settings.Default.DisablePasswordAndCreditCardSync;
+                    break;
+
                 case "CloudStorageProviders":
                     value = new List<ICloudStorageProvider> {
                                                                 new DropBoxProvider(new DropBoxTokenProvider()),

--- a/ClipboardZanager/Sources/ClipboardZanager/Properties/Settings.Designer.cs
+++ b/ClipboardZanager/Sources/ClipboardZanager/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace ClipboardZanager.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "15.1.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "15.3.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
@@ -306,6 +306,18 @@ namespace ClipboardZanager.Properties {
             }
             set {
                 this["CurrentVersion"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("True")]
+        public bool DisablePasswordAndCreditCardSync {
+            get {
+                return ((bool)(this["DisablePasswordAndCreditCardSync"]));
+            }
+            set {
+                this["DisablePasswordAndCreditCardSync"] = value;
             }
         }
     }

--- a/ClipboardZanager/Sources/ClipboardZanager/Properties/Settings.settings
+++ b/ClipboardZanager/Sources/ClipboardZanager/Properties/Settings.settings
@@ -74,5 +74,8 @@
     <Setting Name="CurrentVersion" Type="System.String" Scope="User">
       <Value Profile="(Default)" />
     </Setting>
+    <Setting Name="DisablePasswordAndCreditCardSync" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">True</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/ClipboardZanager/Sources/ClipboardZanager/Strings/LanguageManager.cs
+++ b/ClipboardZanager/Sources/ClipboardZanager/Strings/LanguageManager.cs
@@ -866,6 +866,16 @@ namespace ClipboardZanager.Strings
         public string CreditCard_Description => SettingsSecurityUserControl.SettingsSecurityUserControl.CreditCard_Description;
 
         /// <summary>
+        /// Gets the resource DisableSync.
+        /// </summary>
+        public string DisableSync => SettingsSecurityUserControl.SettingsSecurityUserControl.DisableSync;
+
+        /// <summary>
+        /// Gets the resource DisableSync_Description.
+        /// </summary>
+        public string DisableSync_Description => SettingsSecurityUserControl.SettingsSecurityUserControl.DisableSync_Description;
+
+        /// <summary>
         /// Gets the resource IgnoreFromApps.
         /// </summary>
         public string IgnoreFromApps => SettingsSecurityUserControl.SettingsSecurityUserControl.IgnoreFromApps;

--- a/ClipboardZanager/Sources/ClipboardZanager/Strings/SettingsSecurityUserControl/SettingsSecurityUserControl.Designer.cs
+++ b/ClipboardZanager/Sources/ClipboardZanager/Strings/SettingsSecurityUserControl/SettingsSecurityUserControl.Designer.cs
@@ -88,7 +88,7 @@ namespace ClipboardZanager.Strings.SettingsSecurityUserControl {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Disable by default synchronization of passwords and credit cards.
+        ///   Looks up a localized string similar to Disable by default passwords and credit cards cloud synchronization..
         /// </summary>
         internal static string DisableSync {
             get {
@@ -97,7 +97,7 @@ namespace ClipboardZanager.Strings.SettingsSecurityUserControl {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to If the copied data is marked as a password or a credit card, the synchronization with the cloud will be disabled by default for it..
+        ///   Looks up a localized string similar to If the copied data is marked as a password or a credit card, the synchronization with the cloud will be disabled by default..
         /// </summary>
         internal static string DisableSync_Description {
             get {

--- a/ClipboardZanager/Sources/ClipboardZanager/Strings/SettingsSecurityUserControl/SettingsSecurityUserControl.Designer.cs
+++ b/ClipboardZanager/Sources/ClipboardZanager/Strings/SettingsSecurityUserControl/SettingsSecurityUserControl.Designer.cs
@@ -19,7 +19,7 @@ namespace ClipboardZanager.Strings.SettingsSecurityUserControl {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class SettingsSecurityUserControl {
@@ -84,6 +84,24 @@ namespace ClipboardZanager.Strings.SettingsSecurityUserControl {
         internal static string CreditCard_Description {
             get {
                 return ResourceManager.GetString("CreditCard_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Disable by default synchronization of passwords and credit cards.
+        /// </summary>
+        internal static string DisableSync {
+            get {
+                return ResourceManager.GetString("DisableSync", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to If the copied data is marked as a password or a credit card, the synchronization with the cloud will be disabled by default for it..
+        /// </summary>
+        internal static string DisableSync_Description {
+            get {
+                return ResourceManager.GetString("DisableSync_Description", resourceCulture);
             }
         }
         

--- a/ClipboardZanager/Sources/ClipboardZanager/Strings/SettingsSecurityUserControl/SettingsSecurityUserControl.fr.resx
+++ b/ClipboardZanager/Sources/ClipboardZanager/Strings/SettingsSecurityUserControl/SettingsSecurityUserControl.fr.resx
@@ -59,46 +59,46 @@
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
-  <xsd:schema xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata" id="root">
-    <xsd:import namespace="http://www.w3.org/XML/1998/namespace"/>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
       <xsd:complexType>
         <xsd:choice maxOccurs="unbounded">
           <xsd:element name="metadata">
             <xsd:complexType>
               <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0"/>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
               </xsd:sequence>
-              <xsd:attribute name="name" use="required" type="xsd:string"/>
-              <xsd:attribute name="type" type="xsd:string"/>
-              <xsd:attribute name="mimetype" type="xsd:string"/>
-              <xsd:attribute ref="xml:space"/>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="assembly">
             <xsd:complexType>
-              <xsd:attribute name="alias" type="xsd:string"/>
-              <xsd:attribute name="name" type="xsd:string"/>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="data">
             <xsd:complexType>
               <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1"/>
-                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2"/>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
               </xsd:sequence>
-              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1"/>
-              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3"/>
-              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4"/>
-              <xsd:attribute ref="xml:space"/>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="resheader">
             <xsd:complexType>
               <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1"/>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
               </xsd:sequence>
-              <xsd:attribute name="name" type="xsd:string" use="required"/>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
             </xsd:complexType>
           </xsd:element>
         </xsd:choice>
@@ -125,6 +125,12 @@
   </data>
   <data name="CreditCard_Description" xml:space="preserve">
     <value>Essaye de détecter un texte copié qui ressemble à un numéro de carte de crédit, et évite de le conserver dans l'historique par sécurité.</value>
+  </data>
+  <data name="DisableSync" xml:space="preserve">
+    <value>Désactive par défaut la synchronisation des mots de passes et cartes de crédit</value>
+  </data>
+  <data name="DisableSync_Description" xml:space="preserve">
+    <value>Si le texte copié est marqué comme mot de passe ou carte de crédit, la synchronisation avec le cloud va être désactivée par défaut pour celui-ci.</value>
   </data>
   <data name="IgnoreFromApps" xml:space="preserve">
     <value>Ignorer les données copiées provenant des applications suivantes</value>

--- a/ClipboardZanager/Sources/ClipboardZanager/Strings/SettingsSecurityUserControl/SettingsSecurityUserControl.fr.resx
+++ b/ClipboardZanager/Sources/ClipboardZanager/Strings/SettingsSecurityUserControl/SettingsSecurityUserControl.fr.resx
@@ -127,10 +127,10 @@
     <value>Essaye de détecter un texte copié qui ressemble à un numéro de carte de crédit, et évite de le conserver dans l'historique par sécurité.</value>
   </data>
   <data name="DisableSync" xml:space="preserve">
-    <value>Désactive par défaut la synchronisation des mots de passes et cartes de crédit</value>
+    <value>Désactiver par défaut la synchronisation des mots de passes et cartes de crédit</value>
   </data>
   <data name="DisableSync_Description" xml:space="preserve">
-    <value>Si le texte copié est marqué comme mot de passe ou carte de crédit, la synchronisation avec le cloud va être désactivée par défaut pour celui-ci.</value>
+    <value>Si le texte copié est marqué comme mot de passe ou carte de crédit, la synchronisation avec le cloud sera désactivée par défaut.</value>
   </data>
   <data name="IgnoreFromApps" xml:space="preserve">
     <value>Ignorer les données copiées provenant des applications suivantes</value>

--- a/ClipboardZanager/Sources/ClipboardZanager/Strings/SettingsSecurityUserControl/SettingsSecurityUserControl.resx
+++ b/ClipboardZanager/Sources/ClipboardZanager/Strings/SettingsSecurityUserControl/SettingsSecurityUserControl.resx
@@ -127,10 +127,10 @@
     <value>Try to detect a copied text that looks like a credit card number, and avoid to keep it in memory for safety.</value>
   </data>
   <data name="DisableSync" xml:space="preserve">
-    <value>Disable by default synchronization of passwords and credit cards</value>
+    <value>Disable by default passwords and credit cards cloud synchronization.</value>
   </data>
   <data name="DisableSync_Description" xml:space="preserve">
-    <value>If the copied data is marked as a password or a credit card, the synchronization with the cloud will be disabled by default for it.</value>
+    <value>If the copied data is marked as a password or a credit card, the synchronization with the cloud will be disabled by default.</value>
   </data>
   <data name="IgnoreFromApps" xml:space="preserve">
     <value>Ignore the copied data from the following applications</value>

--- a/ClipboardZanager/Sources/ClipboardZanager/Strings/SettingsSecurityUserControl/SettingsSecurityUserControl.resx
+++ b/ClipboardZanager/Sources/ClipboardZanager/Strings/SettingsSecurityUserControl/SettingsSecurityUserControl.resx
@@ -126,6 +126,12 @@
   <data name="CreditCard_Description" xml:space="preserve">
     <value>Try to detect a copied text that looks like a credit card number, and avoid to keep it in memory for safety.</value>
   </data>
+  <data name="DisableSync" xml:space="preserve">
+    <value>Disable by default synchronization of passwords and credit cards</value>
+  </data>
+  <data name="DisableSync_Description" xml:space="preserve">
+    <value>If the copied data is marked as a password or a credit card, the synchronization with the cloud will be disabled by default for it.</value>
+  </data>
   <data name="IgnoreFromApps" xml:space="preserve">
     <value>Ignore the copied data from the following applications</value>
   </data>

--- a/ClipboardZanager/Sources/ClipboardZanager/ViewModels/SettingsPanels/SettingsSecurityUserControlViewModel.cs
+++ b/ClipboardZanager/Sources/ClipboardZanager/ViewModels/SettingsPanels/SettingsSecurityUserControlViewModel.cs
@@ -43,6 +43,21 @@ namespace ClipboardZanager.ViewModels.SettingsPanels
         public LanguageManager Language => LanguageManager.GetInstance();
 
         /// <summary>
+        /// Gets or sets whether the credit card numbers and password must be synchronized when it is detected
+        /// </summary>
+        public bool DisablePasswordAndCreditCardSync
+        {
+            get { return Settings.Default.DisablePasswordAndCreditCardSync; }
+            set
+            {
+                Logger.Instance.Information($"The setting '{nameof(DisablePasswordAndCreditCardSync)}' has been set to '{value}'.");
+                Settings.Default.DisablePasswordAndCreditCardSync = value;
+                RaisePropertyChanged();
+                _settingProvider.SaveAndApplySettings();
+            }
+        }
+
+        /// <summary>
         /// Gets or sets whether the credit card numbers must be captured when it is detected.
         /// </summary>
         public bool AvoidCreditCard

--- a/ClipboardZanager/Sources/ClipboardZanager/Views/SettingsPanels/SettingsSecurityUserControl.xaml
+++ b/ClipboardZanager/Sources/ClipboardZanager/Views/SettingsPanels/SettingsSecurityUserControl.xaml
@@ -27,6 +27,9 @@
         <CheckBox Content="{Binding Language.SettingsSecurityUserControl.Passwords}" AutomationProperties.HelpText="{Binding Language.SettingsSecurityUserControl.Passwords_Description}" IsChecked="{Binding AvoidPasswords, Mode=TwoWay}" Margin="0,20,0,0"/>
         <TextBlock Text="{Binding Language.SettingsSecurityUserControl.Passwords_Description}" TextWrapping="Wrap" Margin="30,0,0,0"/>
 
+        <CheckBox Content="{Binding Language.SettingsSecurityUserControl.DisableSync}" AutomationProperties.HelpText="{Binding Language.SettingsSecurityUserControl.DisableSync_Description}" IsChecked="{Binding DisablePasswordAndCreditCardSync, Mode=TwoWay}" Margin="0,20,0,0"/>
+        <TextBlock Text="{Binding Language.SettingsSecurityUserControl.DisableSync_Description}" TextWrapping="Wrap" Margin="30,0,0,0"/>
+
         <StackPanel Orientation="Horizontal" Margin="0,20,0,0">
             <TextBlock Text="{Binding Language.SettingsSecurityUserControl.IgnoreFromApps}" VerticalAlignment="Center"/>
             <TextBlock Text=" : " VerticalAlignment="Center"/>

--- a/ClipboardZanager/Tests/ClipboardZanager.Core.Desktop.Tests/Mocks/ServiceSettingProviderMock.cs
+++ b/ClipboardZanager/Tests/ClipboardZanager.Core.Desktop.Tests/Mocks/ServiceSettingProviderMock.cs
@@ -13,6 +13,7 @@ namespace ClipboardZanager.Core.Desktop.Tests.Mocks
         internal bool KeepDataAfterReboot;
         internal bool AvoidPasswords;
         internal bool AvoidCreditCard;
+        internal bool DisablePasswordAndCreditCardSync;
         internal int MaxDataToKeep;
         internal int DateExpireLimit;
         internal ArrayList KeepDataTypes;
@@ -78,6 +79,10 @@ namespace ClipboardZanager.Core.Desktop.Tests.Mocks
                                                             };
                     break;
 
+                case "DisablePasswordAndCreditCardSync":
+                    value = DisablePasswordAndCreditCardSync;
+                    break;
+
                 default:
                     Logger.Instance.Fatal(new KeyNotFoundException($"{settingName} not found."));
                     return default(T);
@@ -96,6 +101,7 @@ namespace ClipboardZanager.Core.Desktop.Tests.Mocks
             KeepDataAfterReboot = true;
             AvoidPasswords = true;
             AvoidCreditCard = true;
+            DisablePasswordAndCreditCardSync = true;
             MaxDataToKeep = 25;
             DateExpireLimit = 30;
             IgnoredApplications = new List<IgnoredApplication>();

--- a/ClipboardZanager/Tests/ClipboardZanager.Core.Desktop.Tests/Service/DataServiceTests.cs
+++ b/ClipboardZanager/Tests/ClipboardZanager.Core.Desktop.Tests/Service/DataServiceTests.cs
@@ -364,6 +364,49 @@ namespace ClipboardZanager.Core.Desktop.Tests.Service
             Assert.IsTrue(service.Cache.All(dataEntryCache => dataEntryCache.Status == DataEntryStatus.Deleted));
         }
 
+        [TestMethod]
+        public void DataService_DisablePasswordAndCreditCardSync()
+        {
+            var window = new Models.Window(IntPtr.Zero, "Edge", new Process(), "Microsoft.MicrosoftEdge", null, true);
+
+            var service = GetDataService();
+            var dataObject = new DataObject();
+            var entry = new ClipboardHookEventArgs(dataObject, false, DateTime.Now.Ticks);
+
+            service.AddDataEntry(entry, new List<DataIdentifier>(), window, false, false);
+
+            var dataEntry = service.DataEntries[0];
+            Assert.IsTrue(dataEntry.CanSynchronize);
+
+            service.AddDataEntry(entry, new List<DataIdentifier>(), window, true, false);
+
+            dataEntry = service.DataEntries[0];
+            Assert.IsFalse(dataEntry.CanSynchronize);
+
+            service.AddDataEntry(entry, new List<DataIdentifier>(), window, false, true);
+
+            dataEntry = service.DataEntries[0];
+            Assert.IsFalse(dataEntry.CanSynchronize);
+
+            TestUtilities.GetSettingProvider().DisablePasswordAndCreditCardSync = false;
+
+            service.AddDataEntry(entry, new List<DataIdentifier>(), window, false, false);
+
+            dataEntry = service.DataEntries[0];
+            Assert.IsTrue(dataEntry.CanSynchronize);
+
+            service.AddDataEntry(entry, new List<DataIdentifier>(), window, true, false);
+
+            dataEntry = service.DataEntries[0];
+            Assert.IsTrue(dataEntry.CanSynchronize);
+
+            service.AddDataEntry(entry, new List<DataIdentifier>(), window, false, true);
+
+            dataEntry = service.DataEntries[0];
+            Assert.IsTrue(dataEntry.CanSynchronize);
+
+        }
+
         private DataService GetDataService()
         {
             return ServiceLocator.GetService<DataService>();


### PR DESCRIPTION
Add an option so passwords and credit cards are no longer synchronized by default (option enabled by default)