### PR TITLE
New shortcut to recopy or paste a data from the paste bar.

### DIFF
--- a/Android/app/build.gradle
+++ b/Android/app/build.gradle
@@ -34,7 +34,7 @@ android {
         minSdkVersion 21
         targetSdkVersion 25
         versionCode 1
-        versionName "2017.9.3.56" // Do NOT change this line manually. It is changed automatically everytime the Windows app is built.
+        versionName "2017.9.6.1" // Do NOT change this line manually. It is changed automatically everytime the Windows app is built.
         // Do NOT change this line manually. It is changed automatically everytime the Windows app is built.
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
         jackOptions {

--- a/ClipboardZanager/Sources/ClipboardZanager/Properties/AssemblyInfo.cs
+++ b/ClipboardZanager/Sources/ClipboardZanager/Properties/AssemblyInfo.cs
@@ -55,8 +55,8 @@ using System.Windows;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2017.9.3.56")]
-[assembly: AssemblyFileVersion("2017.9.3.56")]
+[assembly: AssemblyVersion("2017.9.6.1")]
+[assembly: AssemblyFileVersion("2017.9.6.1")]
 
 [assembly: InternalsVisibleTo("ClipboardZanager.Tests")]
 

--- a/ClipboardZanager/Sources/ClipboardZanager/Views/PasteBarWindow.xaml
+++ b/ClipboardZanager/Sources/ClipboardZanager/Views/PasteBarWindow.xaml
@@ -94,6 +94,8 @@
             <ListBox x:Name="DataListBox" Grid.Row="1" ItemsSource="{Binding DataEntries, IsAsync=True, Mode=OneWay}" Style="{StaticResource PasteBarListBox}" Visibility="{Binding NoPresentData, Converter={StaticResource InvertedBooleanToVisibilityConverter}}">
                 <ListBox.InputBindings>
                     <KeyBinding Key="Enter" Command="{Binding PasteCommand}" CommandParameter="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type ListBox}}, Path=SelectedValue}"/>
+                    <KeyBinding Modifiers="Ctrl" Key="V" Command="{Binding PasteCommand}" CommandParameter="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type ListBox}}, Path=SelectedValue}"/>
+                    <KeyBinding Modifiers="Ctrl" Key="C" Command="{Binding CopyCommand}" CommandParameter="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type ListBox}}, Path=SelectedValue}"/>
                 </ListBox.InputBindings>
                 <i:Interaction.Triggers>
                     <i:EventTrigger EventName="MouseDoubleClick">


### PR DESCRIPTION
Added 2 shortcuts : when the paste bar is open, select a data and press Ctrl+C to copy the selected data, or Ctrl+V to paste it to the foreground window.