### PR TITLE
Added the support of hexadecimal colors.

### DIFF
--- a/Android/app/build.gradle
+++ b/Android/app/build.gradle
@@ -34,7 +34,7 @@ android {
         minSdkVersion 21
         targetSdkVersion 25
         versionCode 1
-        versionName "2017.9.6.1" // Do NOT change this line manually. It is changed automatically everytime the Windows app is built.
+        versionName "2017.9.7.9" // Do NOT change this line manually. It is changed automatically everytime the Windows app is built.
         // Do NOT change this line manually. It is changed automatically everytime the Windows app is built.
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
         jackOptions {

--- a/Android/app/src/androidTest/java/com/etiennebaudoux/clipboardzanager/componentmodel/services/DataServiceTests.java
+++ b/Android/app/src/androidTest/java/com/etiennebaudoux/clipboardzanager/componentmodel/services/DataServiceTests.java
@@ -53,6 +53,25 @@ public class DataServiceTests {
     }
 
     @Test
+    public void isHexColor() throws Exception {
+        DataService service = getDataService();
+
+        assertTrue(service.isHexColor("#1f1f1F"));
+        assertTrue(service.isHexColor("#AFAFAF"));
+        assertTrue(service.isHexColor("#1AFFa1"));
+        assertTrue(service.isHexColor("#222fff"));
+        assertTrue(service.isHexColor("#F00"));
+        assertTrue(service.isHexColor("#bbffffff"));
+        assertFalse(service.isHexColor("123456"));
+        assertFalse(service.isHexColor("#afafah"));
+        assertFalse(service.isHexColor("#123abce"));
+        assertFalse(service.isHexColor("aFaE3f"));
+        assertFalse(service.isHexColor("F00"));
+        assertFalse(service.isHexColor("#afaf"));
+        assertFalse(service.isHexColor("#F0h"));
+    }
+
+    @Test
     public void isCreditCard() throws Exception {
         DataService service = getDataService();
 

--- a/Android/app/src/main/java/com/etiennebaudoux/clipboardzanager/componentmodel/services/DataService.java
+++ b/Android/app/src/main/java/com/etiennebaudoux/clipboardzanager/componentmodel/services/DataService.java
@@ -133,7 +133,7 @@ public class DataService implements Service {
      * @return Returns True is the string looks like a hex color number
      */
     public boolean isHexColor(String input) {
-        return (input.length() == 9 || input.length() == 7 || input.length() == 4) && _hexColorRegex.matcher(input).matches();
+        return _hexColorRegex.matcher(input).matches();
     }
 
     /**

--- a/Android/app/src/main/java/com/etiennebaudoux/clipboardzanager/componentmodel/services/DataService.java
+++ b/Android/app/src/main/java/com/etiennebaudoux/clipboardzanager/componentmodel/services/DataService.java
@@ -49,6 +49,7 @@ public class DataService implements Service {
     private final Pattern _hasNumber = Pattern.compile("^(?=.*\\d).+$");
     private final Pattern _hasUpperChar = Pattern.compile("^(?=.*[A-Z]).+$");
     private final Pattern _uriPattern = Pattern.compile("\\b(https?|ftp)://[-a-zA-Z0-9+&@#/%?=~_|!:,.;]*[-a-zA-Z0-9+&@#/%=~_|]");
+    private final Pattern _hexColorRegex = Pattern.compile("^#([A-Fa-f0-9]{8}|[A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$");
 
     private boolean _lastCopiedDataWasCreditCard;
     private boolean _lastCopiedDataWasPassword;
@@ -123,6 +124,16 @@ public class DataService implements Service {
         _lastCopiedDataWasCreditCard = false;
         _lastCopiedDataWasPassword = false;
         _detectedPasswordOrCreditCard = null;
+    }
+
+    /**
+     * Determines whether the input string looks like a hex color or not.
+     *
+     * @param input The string to test
+     * @return Returns True is the string looks like a hex color number
+     */
+    public boolean isHexColor(String input) {
+        return (input.length() == 9 || input.length() == 7 || input.length() == 4) && _hexColorRegex.matcher(input).matches();
     }
 
     /**
@@ -556,6 +567,7 @@ public class DataService implements Service {
      */
     private Thumbnail generateThumbnail(String text, boolean isCreditCard, boolean isPassword) throws IOException {
         @ThumbnailDataType int type = ThumbnailDataType.UNKNOWN;
+        String value = "";
 
         if (isCreditCard) {
             if (!StringUtils.isNullOrEmpty(text)) {
@@ -571,21 +583,25 @@ public class DataService implements Service {
             }
         } else if (isPassword) {
             text = text.substring(0, 1) + new String(new char[text.length() - 2]).replace("\0", Consts.PasswordMask) + text.substring(text.length() - 1);
+        } else if (isHexColor(text)) {
+            type = ThumbnailDataType.COLOR;
+            value = DataHelper.toBase64(text);
         } else if (text.length() > 253) {
             text = text.substring(0, Math.min(text.length(), 250));
             text += "...";
         }
 
-        String value;
-        boolean isUri = _uriPattern.matcher(text).matches();
-        if (isUri) {
-            type = ThumbnailDataType.LINK;
-            Link link = new Link();
-            link.setUri(text);
-            value = DataHelper.toBase64(link);
-        } else {
-            type = ThumbnailDataType.STRING;
-            value = DataHelper.toBase64(text);
+        if (type == ThumbnailDataType.UNKNOWN) {
+            boolean isUri = _uriPattern.matcher(text).matches();
+            if (isUri) {
+                type = ThumbnailDataType.LINK;
+                Link link = new Link();
+                link.setUri(text);
+                value = DataHelper.toBase64(link);
+            } else {
+                type = ThumbnailDataType.STRING;
+                value = DataHelper.toBase64(text);
+            }
         }
 
         Thumbnail thumbnail = new Thumbnail();

--- a/Android/app/src/main/java/com/etiennebaudoux/clipboardzanager/enums/ThumbnailDataType.java
+++ b/Android/app/src/main/java/com/etiennebaudoux/clipboardzanager/enums/ThumbnailDataType.java
@@ -6,7 +6,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 
 @IntDef({ThumbnailDataType.UNKNOWN, ThumbnailDataType.STRING, ThumbnailDataType.FILE,
-        ThumbnailDataType.BITMAP, ThumbnailDataType.LINK})
+        ThumbnailDataType.BITMAP, ThumbnailDataType.LINK, ThumbnailDataType.COLOR})
 @Retention(RetentionPolicy.SOURCE)
 public @interface ThumbnailDataType {
     int UNKNOWN = 0;
@@ -14,4 +14,5 @@ public @interface ThumbnailDataType {
     int FILE = 2;
     int BITMAP = 3;
     int LINK = 4;
+    int COLOR = 5;
 }

--- a/ClipboardZanager/Sources/ClipboardZanager.Core.Desktop/Enums/ThumbnailDataType.cs
+++ b/ClipboardZanager/Sources/ClipboardZanager.Core.Desktop/Enums/ThumbnailDataType.cs
@@ -6,6 +6,7 @@
         String = 1,
         Files = 2,
         Bitmap = 3,
-        Link = 4
+        Link = 4,
+        Color = 5
     }
 }

--- a/ClipboardZanager/Sources/ClipboardZanager.Core.Desktop/Services/DataService.cs
+++ b/ClipboardZanager/Sources/ClipboardZanager.Core.Desktop/Services/DataService.cs
@@ -143,7 +143,7 @@ namespace ClipboardZanager.Core.Desktop.Services
         /// <returns>Returns True is the string looks like a hex color</returns>
         internal bool IsHexColor(string input)
         {
-            return (input.Length == 9 || input.Length == 7 || input.Length == 4) && _hexColorRegex.IsMatch(input);
+            return _hexColorRegex.IsMatch(input);
         }
 
         /// <summary>

--- a/ClipboardZanager/Sources/ClipboardZanager.Core.Desktop/Services/DataService.cs
+++ b/ClipboardZanager/Sources/ClipboardZanager.Core.Desktop/Services/DataService.cs
@@ -31,6 +31,7 @@ namespace ClipboardZanager.Core.Desktop.Services
         private readonly Regex _creditCardRegex = new Regex(@"^(?:4[0-9]{12}(?:[0-9]{3})?|5[1-5][0-9]{14}|6(?:011|5[0-9][0-9])[0-9]{12}|3[47][0-9]{13}|3(?:0[0-5]|[68][0-9])[0-9]{11}|(?:2131|1800|35\d{3})\d{11})$", RegexOptions.Compiled);
         private readonly Regex _hasNumber = new Regex(@"[0-9]+", RegexOptions.Compiled);
         private readonly Regex _hasUpperChar = new Regex(@"[A-Z]+", RegexOptions.Compiled);
+        private readonly Regex _hexColorRegex = new Regex(@"^#([A-Fa-f0-9]{8}|[A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$", RegexOptions.Compiled);
 
         private bool _lastCopiedDataWasCreditCard;
         private bool _lastCopiedDataWasPassword;
@@ -133,6 +134,16 @@ namespace ClipboardZanager.Core.Desktop.Services
             _lastCopiedDataWasCreditCard = false;
             _lastCopiedDataWasPassword = false;
             _detectedPasswordOrCreditCard = null;
+        }
+
+        /// <summary>
+        /// Determines whether the input string looks like a hex color or not.
+        /// </summary>
+        /// <param name="input">The string to test</param>
+        /// <returns>Returns True is the string looks like a hex color</returns>
+        internal bool IsHexColor(string input)
+        {
+            return (input.Length == 9 || input.Length == 7 || input.Length == 4) && _hexColorRegex.IsMatch(input);
         }
 
         /// <summary>
@@ -428,7 +439,7 @@ namespace ClipboardZanager.Core.Desktop.Services
 
             var dataObject = new DataObject();
 
-            if (dataEntry.Thumbnail.Type == ThumbnailDataType.String)
+            if (dataEntry.Thumbnail.Type == ThumbnailDataType.String || dataEntry.Thumbnail.Type == ThumbnailDataType.Color)
             {
                 var identifier = dataEntry.DataIdentifiers.FirstOrDefault(id => id.FormatName == DataFormats.UnicodeText);
                 if (identifier != null)
@@ -471,7 +482,7 @@ namespace ClipboardZanager.Core.Desktop.Services
                     return MatchText(dataObject, searchQuery.Query);
 
                 case SearchType.Text:
-                    if (dataEntry.Thumbnail.Type == ThumbnailDataType.String)
+                    if (dataEntry.Thumbnail.Type == ThumbnailDataType.String || dataEntry.Thumbnail.Type == ThumbnailDataType.Color)
                     {
                         return MatchText(dataObject, searchQuery.Query);
                     }
@@ -1110,22 +1121,30 @@ namespace ClipboardZanager.Core.Desktop.Services
                 {
                     text = text.Substring(0, 1) + new string(Consts.PasswordMask, text.Length - 2) + text.Substring(text.Length - 1);
                 }
+                else if (IsHexColor(text))
+                {
+                    type = ThumbnailDataType.Color;
+                    value = DataHelper.ToBase64(text);
+                }
                 else if (text.Length > 253)
                 {
                     text = text.Substring(0, Math.Min(text.Length, 250));
                     text += "...";
                 }
 
-                var isUri = Uri.TryCreate(text, UriKind.Absolute, out Uri uriResult) && (uriResult.Scheme == Uri.UriSchemeHttp || uriResult.Scheme == Uri.UriSchemeHttps || uriResult.Scheme == Uri.UriSchemeFtp || uriResult.Scheme == Uri.UriSchemeMailto);
-                if (isUri)
+                if (type == ThumbnailDataType.Unknown)
                 {
-                    type = ThumbnailDataType.Link;
-                    value = DataHelper.ToBase64(new Link { Uri = text });
-                }
-                else
-                {
-                    type = ThumbnailDataType.String;
-                    value = DataHelper.ToBase64(text);
+                    var isUri = Uri.TryCreate(text, UriKind.Absolute, out Uri uriResult) && (uriResult.Scheme == Uri.UriSchemeHttp || uriResult.Scheme == Uri.UriSchemeHttps || uriResult.Scheme == Uri.UriSchemeFtp || uriResult.Scheme == Uri.UriSchemeMailto);
+                    if (isUri)
+                    {
+                        type = ThumbnailDataType.Link;
+                        value = DataHelper.ToBase64(new Link { Uri = text });
+                    }
+                    else
+                    {
+                        type = ThumbnailDataType.String;
+                        value = DataHelper.ToBase64(text);
+                    }
                 }
             }
 

--- a/ClipboardZanager/Sources/ClipboardZanager/ComponentModel/UI/Converters/DataEntryToDescriptiveTextConverter.cs
+++ b/ClipboardZanager/Sources/ClipboardZanager/ComponentModel/UI/Converters/DataEntryToDescriptiveTextConverter.cs
@@ -51,6 +51,9 @@ namespace ClipboardZanager.ComponentModel.UI.Converters
                     case Core.Desktop.Enums.ThumbnailDataType.String:
                         return string.Format(language.PasteBarWindow.DataText, DataHelper.FromBase64<string>(dataEntry.Thumbnail.Value));
 
+                    case Core.Desktop.Enums.ThumbnailDataType.Color:
+                        return string.Format(language.PasteBarWindow.DataColor, DataHelper.FromBase64<string>(dataEntry.Thumbnail.Value));
+
                     case Core.Desktop.Enums.ThumbnailDataType.Unknown:
                         return language.PasteBarWindow.DataUnknow;
                 }

--- a/ClipboardZanager/Sources/ClipboardZanager/ComponentModel/UI/Converters/ThumbnailToValueConverter.cs
+++ b/ClipboardZanager/Sources/ClipboardZanager/ComponentModel/UI/Converters/ThumbnailToValueConverter.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Linq;
 using System.Windows;
 using System.Windows.Data;
+using System.Windows.Media;
 
 namespace ClipboardZanager.ComponentModel.UI.Converters
 {
@@ -39,6 +40,10 @@ namespace ClipboardZanager.ComponentModel.UI.Converters
                 {
                     parameterValue = ThumbnailDataType.Link;
                 }
+                else if (parameterStringLower == "solidcolorbrush" || parameterStringLower == "foregroundsolidcolorbrush" || parameterStringLower == "colorstring")
+                {
+                    parameterValue = ThumbnailDataType.Color;
+                }
             }
 
             if (parameterValue != thumbnail.Type)
@@ -61,6 +66,24 @@ namespace ClipboardZanager.ComponentModel.UI.Converters
 
                 case ThumbnailDataType.String:
                     return DataHelper.FromBase64<string>(thumbnail.Value);
+
+                case ThumbnailDataType.Color:
+                    var colorString = DataHelper.FromBase64<string>(thumbnail.Value);
+                    if (parameterStringLower == "solidcolorbrush")
+                    {
+                        return new SolidColorBrush((Color)ColorConverter.ConvertFromString(colorString));
+                    }
+                    else if (parameterStringLower == "foregroundsolidcolorbrush") 
+                    {
+                        var color = (Color)ColorConverter.ConvertFromString(colorString);
+                        // check the brightness of the color to determine whether the text must be black or white.
+                        if ((int)Math.Sqrt(color.R * color.R * .241 + color.G * color.G * .691 + color.B * color.B * .068) > 130)
+                        {
+                            return new SolidColorBrush(Color.FromRgb(0, 0, 0));
+                        }
+                        return new SolidColorBrush(Color.FromRgb(255, 255, 255));
+                    }
+                    return colorString;
 
                 case ThumbnailDataType.Files:
                     var filesSource = thumbnail.GetFilesPath();

--- a/ClipboardZanager/Sources/ClipboardZanager/Properties/AssemblyInfo.cs
+++ b/ClipboardZanager/Sources/ClipboardZanager/Properties/AssemblyInfo.cs
@@ -55,8 +55,8 @@ using System.Windows;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2017.9.6.1")]
-[assembly: AssemblyFileVersion("2017.9.6.1")]
+[assembly: AssemblyVersion("2017.9.7.9")]
+[assembly: AssemblyFileVersion("2017.9.7.9")]
 
 [assembly: InternalsVisibleTo("ClipboardZanager.Tests")]
 

--- a/ClipboardZanager/Sources/ClipboardZanager/Strings/LanguageManager.cs
+++ b/ClipboardZanager/Sources/ClipboardZanager/Strings/LanguageManager.cs
@@ -426,6 +426,11 @@ namespace ClipboardZanager.Strings
         public string Copy_Tooltip => PasteBarWindow.PasteBarWindow.Copy_Tooltip;
 
         /// <summary>
+        /// Gets the resource DataColor.
+        /// </summary>
+        public string DataColor => PasteBarWindow.PasteBarWindow.DataColor;
+
+        /// <summary>
         /// Gets the resource DataFile.
         /// </summary>
         public string DataFile => PasteBarWindow.PasteBarWindow.DataFile;

--- a/ClipboardZanager/Sources/ClipboardZanager/Strings/PasteBarWindow/PasteBarWindow.Designer.cs
+++ b/ClipboardZanager/Sources/ClipboardZanager/Strings/PasteBarWindow/PasteBarWindow.Designer.cs
@@ -106,6 +106,15 @@ namespace ClipboardZanager.Strings.PasteBarWindow {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to This data is a color : {0}.
+        /// </summary>
+        internal static string DataColor {
+            get {
+                return ResourceManager.GetString("DataColor", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to This data is a set of copied files : {0}.
         /// </summary>
         internal static string DataFile {

--- a/ClipboardZanager/Sources/ClipboardZanager/Strings/PasteBarWindow/PasteBarWindow.fr.resx
+++ b/ClipboardZanager/Sources/ClipboardZanager/Strings/PasteBarWindow/PasteBarWindow.fr.resx
@@ -132,6 +132,9 @@
   <data name="Copy_Tooltip" xml:space="preserve">
     <value>Mettre la donnée dans le presse-papiers</value>
   </data>
+  <data name="DataColor" xml:space="preserve">
+    <value>Cette donnée est une couleur : {0}</value>
+  </data>
   <data name="DataFile" xml:space="preserve">
     <value>Cette donnée est un ensemble de fichiers copiés : {0}</value>
   </data>

--- a/ClipboardZanager/Sources/ClipboardZanager/Strings/PasteBarWindow/PasteBarWindow.resx
+++ b/ClipboardZanager/Sources/ClipboardZanager/Strings/PasteBarWindow/PasteBarWindow.resx
@@ -132,6 +132,9 @@
   <data name="Copy_Tooltip" xml:space="preserve">
     <value>Put the data in the clipboard</value>
   </data>
+  <data name="DataColor" xml:space="preserve">
+    <value>This data is a color : {0}</value>
+  </data>
   <data name="DataFile" xml:space="preserve">
     <value>This data is a set of copied files : {0}</value>
   </data>

--- a/ClipboardZanager/Sources/ClipboardZanager/Views/PasteBarWindow.xaml
+++ b/ClipboardZanager/Sources/ClipboardZanager/Views/PasteBarWindow.xaml
@@ -233,6 +233,16 @@
                                         <TextBlock Text="{Binding Thumbnail, ConverterParameter=String, Converter={StaticResource ThumbnailToValueConverter}, Mode=OneTime}" Foreground="{StaticResource ForegroundBrush}" Margin="10,5,10,0" TextAlignment="Left" FontSize="20" TextWrapping="Wrap"/>
                                         <Border Height="40" VerticalAlignment="Bottom" Background="{StaticResource PasteBarItemLinearGradentBorderBackground}"/>
                                     </Grid>
+                                    <Grid Visibility="{Binding Thumbnail.Type, ConverterParameter=Color, Converter={StaticResource EnumToVisibilityConverter}, Mode=OneTime}">
+                                        <Canvas>
+                                            <Canvas.CacheMode>
+                                                <BitmapCache EnableClearType="True" RenderAtScale="1.0" PresentationOptions:Freeze="True"/>
+                                            </Canvas.CacheMode>
+                                            <Rectangle Width="{Binding ActualWidth, Mode=OneWay, ElementName=ThumbnailGrid}" Height="{Binding ActualHeight, Mode=OneWay, ElementName=ThumbnailGrid}" Fill="{StaticResource PasteBarItemTiledImageBackground}"/>
+                                        </Canvas>
+                                        <DockPanel Background="{Binding Thumbnail, ConverterParameter=SolidColorBrush, Converter={StaticResource ThumbnailToValueConverter}, Mode=OneTime}"/>
+                                        <TextBlock Text="{Binding Thumbnail, ConverterParameter=ColorString, Converter={StaticResource ThumbnailToValueConverter}, Mode=OneTime}" Foreground="{Binding Thumbnail, ConverterParameter=ForegroundSolidColorBrush, Converter={StaticResource ThumbnailToValueConverter}, Mode=OneTime}" TextAlignment="Center" VerticalAlignment="Center" FontSize="20" TextWrapping="Wrap"/>
+                                    </Grid>
                                     <Grid Visibility="{Binding Thumbnail.Type, ConverterParameter=Link, Converter={StaticResource EnumToVisibilityConverter}, Mode=OneTime}">
                                         <Grid.RowDefinitions>
                                             <RowDefinition Height="Auto"/>

--- a/ClipboardZanager/Tests/ClipboardZanager.Core.Desktop.Tests/Service/DataServiceTests.cs
+++ b/ClipboardZanager/Tests/ClipboardZanager.Core.Desktop.Tests/Service/DataServiceTests.cs
@@ -40,6 +40,26 @@ namespace ClipboardZanager.Core.Desktop.Tests.Service
         }
 
         [TestMethod]
+        public void DataService_IsHexColor()
+        {
+            var service = GetDataService();
+
+            Assert.IsTrue(service.IsHexColor("#1f1f1F"));
+            Assert.IsTrue(service.IsHexColor("#AFAFAF"));
+            Assert.IsTrue(service.IsHexColor("#1AFFa1"));
+            Assert.IsTrue(service.IsHexColor("#222fff"));
+            Assert.IsTrue(service.IsHexColor("#F00"));
+            Assert.IsTrue(service.IsHexColor("#bbffffff"));
+            Assert.IsFalse(service.IsHexColor("123456"));
+            Assert.IsFalse(service.IsHexColor("#afafah"));
+            Assert.IsFalse(service.IsHexColor("#123abce"));
+            Assert.IsFalse(service.IsHexColor("aFaE3f"));
+            Assert.IsFalse(service.IsHexColor("F00"));
+            Assert.IsFalse(service.IsHexColor("#afaf"));
+            Assert.IsFalse(service.IsHexColor("#F0h"));
+        }
+
+        [TestMethod]
         public void DataService_IsCreditCard()
         {
             var service = GetDataService();
@@ -205,6 +225,21 @@ namespace ClipboardZanager.Core.Desktop.Tests.Service
 
             Assert.AreEqual(dataEntry.Thumbnail.Type, ThumbnailDataType.String);
             Assert.AreEqual(DataHelper.FromBase64<string>(dataEntry.Thumbnail.Value), "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It h...");
+        }
+
+        [TestMethod]
+        public void DataService_DataEntry_Thumbnail_Color()
+        {
+            var service = GetDataService();
+            var dataObject = new DataObject();
+            dataObject.SetText("#Fff002");
+            var entry = new ClipboardHookEventArgs(dataObject, false, DateTime.Now.Ticks);
+
+            service.AddDataEntry(entry, new List<DataIdentifier>(), ServiceLocator.GetService<WindowsService>().GetForegroundWindow(), false, false);
+
+            var dataEntry = service.DataEntries.First();
+
+            Assert.AreEqual(dataEntry.Thumbnail.Type, ThumbnailDataType.Color);
         }
 
         [TestMethod]

--- a/ClipboardZanager/Tests/ClipboardZanager.Tests/ViewModels/PasteBarWindowViewModelTests.cs
+++ b/ClipboardZanager/Tests/ClipboardZanager.Tests/ViewModels/PasteBarWindowViewModelTests.cs
@@ -119,6 +119,16 @@ namespace ClipboardZanager.Tests.ViewModels
             }, 100);
 
             dataObject = new DataObject();
+            dataObject.SetText("#ffffff");
+            entry = new ClipboardHookEventArgs(dataObject, false, DateTime.Now.Ticks);
+            DispatcherUtil.ExecuteOnDispatcherThread(() =>
+            {
+                service.ClipboardHook_ClipboardChanged(null, entry);
+                Task.Delay(300).Wait();
+                DispatcherUtil.DoEvents();
+            }, 100);
+
+            dataObject = new DataObject();
             dataObject.SetText("http://www.ipsum.com/");
             entry = new ClipboardHookEventArgs(dataObject, false, DateTime.Now.Ticks);  
             DispatcherUtil.ExecuteOnDispatcherThread(() =>
@@ -139,7 +149,7 @@ namespace ClipboardZanager.Tests.ViewModels
             }, 100);
 
             var viewmodel = new PasteBarWindowViewModel();
-            Assert.AreEqual(viewmodel.CollectionView.Cast<DataEntry>().Count(), 4);
+            Assert.AreEqual(viewmodel.CollectionView.Cast<DataEntry>().Count(), 5);
 
             viewmodel.SearchQueryString = "ipsum";
             viewmodel.SearchCommand.CheckBeginExecute(true);
@@ -150,6 +160,14 @@ namespace ClipboardZanager.Tests.ViewModels
             Assert.AreEqual(viewmodel.CollectionView.Cast<DataEntry>().Count(), 3);
 
             viewmodel.SearchQueryString = "Ipsum";
+            viewmodel.SearchCommand.CheckBeginExecute(true);
+            viewmodel.IgnoreSearch = false;
+            await Task.Delay(500);
+            DispatcherUtil.DoEvents();
+
+            Assert.AreEqual(viewmodel.CollectionView.Cast<DataEntry>().Count(), 1);
+
+            viewmodel.SearchQueryString = "#fff";
             viewmodel.SearchCommand.CheckBeginExecute(true);
             viewmodel.IgnoreSearch = false;
             await Task.Delay(500);


### PR DESCRIPTION
Added of the support of colors copied in 3 formats : 
- `#fff` : RGB
- `#ffffff` : RRGGBB
- `#ffffffff` : AARRGGBB

Render on Windows : 
![pasted image at 2017_09_06 09_21 pm](https://user-images.githubusercontent.com/3747805/30146408-b76e8806-934c-11e7-896c-e961d06fb201.png)

The backend on Android must corresponds to the same on Windows. @vmichalak , please take a look :-) 
