### PR TITLE
Fix #33 - IsMeteredConnection had a NullReferenceException in some cases

### DIFF
--- a/ClipboardZanager/Sources/ClipboardZanager.Core.Desktop/ComponentModel/SystemInfoHelper.cs
+++ b/ClipboardZanager/Sources/ClipboardZanager.Core.Desktop/ComponentModel/SystemInfoHelper.cs
@@ -81,7 +81,12 @@ namespace ClipboardZanager.Core.Desktop.ComponentModel
                 return false;
             }
 
-            var connectionCost = NetworkInformation.GetInternetConnectionProfile().GetConnectionCost();
+            if (connectionProfile.GetConnectionCost() == null)
+            {
+                return false;
+            }
+
+            var connectionCost = connectionProfile.GetConnectionCost();
             return connectionCost.NetworkCostType != NetworkCostType.Unknown && connectionCost.NetworkCostType != NetworkCostType.Unrestricted;
         }
 


### PR DESCRIPTION
Fixed an issue where the IsMeteredConnection was crashing on some devices.