### PR TITLE
Disable passwords and credit cards sync by default on Android

### DIFF
--- a/Android/app/src/androidTest/java/com/etiennebaudoux/clipboardzanager/componentmodel/services/DataServiceTests.java
+++ b/Android/app/src/androidTest/java/com/etiennebaudoux/clipboardzanager/componentmodel/services/DataServiceTests.java
@@ -289,13 +289,40 @@ public class DataServiceTests {
         assertEquals(service.getCache().size(), 10);
 
         assertTrue(service.getCache().all(dataEntryCache -> dataEntryCache.getStatus() == DataEntryStatus.ADDED));
-
         service.removeAllDataAsync().await();
 
         assertEquals(service.getDataEntries().size(), 0);
+
         assertEquals(service.getCache().size(), 10);
 
         assertTrue(service.getCache().all(dataEntryCache -> dataEntryCache.getStatus() == DataEntryStatus.DELETED));
+    }
+
+    @Test
+    public void disablePasswordAndCreditCardSync() throws Exception {
+        DataService service = getDataService();
+        Date date = new Date(System.currentTimeMillis());
+        String value = "Hello";
+
+        service.addDataEntry(new ClipboardData(value, date), new QueryableArrayList<>(), false, false);
+        assertTrue(service.getDataEntries().first().canSynchronize());
+
+        service.addDataEntry(new ClipboardData(value, date), new QueryableArrayList<>(), true, false);
+        assertFalse(service.getDataEntries().first().canSynchronize());
+
+        service.addDataEntry(new ClipboardData(value, date), new QueryableArrayList<>(), false, true);
+        assertFalse(service.getDataEntries().first().canSynchronize());
+
+        TestUtilities.getSettingProvider().DisablePasswordAndCreditCardSync = "false";
+
+        service.addDataEntry(new ClipboardData(value, date), new QueryableArrayList<>(), false, false);
+        assertTrue(service.getDataEntries().first().canSynchronize());
+
+        service.addDataEntry(new ClipboardData(value, date), new QueryableArrayList<>(), true, false);
+        assertTrue(service.getDataEntries().first().canSynchronize());
+
+        service.addDataEntry(new ClipboardData(value, date), new QueryableArrayList<>(), false, true);
+        assertTrue(service.getDataEntries().first().canSynchronize());
     }
 
     private DataService getDataService() {

--- a/Android/app/src/androidTest/java/com/etiennebaudoux/clipboardzanager/mocks/ServiceSettingProviderMock.java
+++ b/Android/app/src/androidTest/java/com/etiennebaudoux/clipboardzanager/mocks/ServiceSettingProviderMock.java
@@ -8,6 +8,7 @@ public class ServiceSettingProviderMock implements ServiceSettingProvider {
     public String KeepDataAfterReboot;
     public String AvoidPasswords;
     public String AvoidCreditCard;
+    public String DisablePasswordAndCreditCardSync;
     public String MaxDataToKeep;
     public String DateExpireLimit;
 
@@ -39,6 +40,10 @@ public class ServiceSettingProviderMock implements ServiceSettingProvider {
                 value = AvoidCreditCard;
                 break;
 
+            case "DisablePasswordAndCreditCardSync":
+                value = DisablePasswordAndCreditCardSync;
+                break;
+
             case "MaxDataToKeep":
                 value = MaxDataToKeep;
                 break;
@@ -67,9 +72,11 @@ public class ServiceSettingProviderMock implements ServiceSettingProvider {
     }
 
     public void resetSettings() {
-        KeepDataAfterReboot = "true";
-        AvoidPasswords = "true";
-        AvoidCreditCard = "true";
+        String trueString = "true";
+        KeepDataAfterReboot = trueString;
+        AvoidPasswords = trueString;
+        AvoidCreditCard = trueString;
+        DisablePasswordAndCreditCardSync = trueString;
         MaxDataToKeep = "25";
         DateExpireLimit = "30";
     }

--- a/Android/app/src/main/java/com/etiennebaudoux/clipboardzanager/App.java
+++ b/Android/app/src/main/java/com/etiennebaudoux/clipboardzanager/App.java
@@ -35,6 +35,7 @@ public class App extends Application {
             CoreHelper.setSetting("MaxDataToKeep", "25");
             CoreHelper.setSetting("DateExpireLimit", "30");
             CoreHelper.setSetting("KeepDataAfterReboot", "true");
+            CoreHelper.setSetting("DisablePasswordAndCreditCardSync", "true");
 
             ServiceLocator.setSettingProvider(new SettingProvider());
 

--- a/Android/app/src/main/java/com/etiennebaudoux/clipboardzanager/componentmodel/services/DataService.java
+++ b/Android/app/src/main/java/com/etiennebaudoux/clipboardzanager/componentmodel/services/DataService.java
@@ -295,12 +295,18 @@ public class DataService implements Service {
         Requires.notNull(data, "data");
         Requires.notNull(identifiers, "identifiers");
 
+        boolean shouldSynchronize = true;
+
+        if (Boolean.parseBoolean(_settingProvider.getSetting("DisablePasswordAndCreditCardSync"))) {
+            shouldSynchronize = !(isPassword || isCreditCard);
+        }
+
         DataEntry entry = new DataEntry();
         entry.setIdentifier(generateNewUUID());
         entry.setThumbnail(generateThumbnail(data.getData(), isCreditCard, isPassword));
         entry.setDate(data.getDate());
         entry.setIsFavorite(false);
-        entry.setCanSynchronize(true);
+        entry.setCanSynchronize(shouldSynchronize);
         entry.setIconIsFromWindowStore(false);
         entry.setDataIdentifiers(identifiers);
 

--- a/Android/app/src/test/java/com/etiennebaudoux/clipboardzanager/mocks/ServiceSettingProviderMock.java
+++ b/Android/app/src/test/java/com/etiennebaudoux/clipboardzanager/mocks/ServiceSettingProviderMock.java
@@ -8,6 +8,7 @@ public class ServiceSettingProviderMock implements ServiceSettingProvider {
     public String KeepDataAfterReboot;
     public String AvoidPasswords;
     public String AvoidCreditCard;
+    public String DisablePasswordAndCreditCardSync;
     public String MaxDataToKeep;
     public String DateExpireLimit;
 
@@ -39,6 +40,10 @@ public class ServiceSettingProviderMock implements ServiceSettingProvider {
                 value = AvoidCreditCard;
                 break;
 
+            case "DisablePasswordAndCreditCardSync":
+                value = DisablePasswordAndCreditCardSync;
+                break;
+
             case "MaxDataToKeep":
                 value = MaxDataToKeep;
                 break;
@@ -67,9 +72,11 @@ public class ServiceSettingProviderMock implements ServiceSettingProvider {
     }
 
     public void resetSettings() {
-        KeepDataAfterReboot = "true";
-        AvoidPasswords = "true";
-        AvoidCreditCard = "true";
+        String trueString = "true";
+        KeepDataAfterReboot = trueString;
+        AvoidPasswords = trueString;
+        AvoidCreditCard = trueString;
+        DisablePasswordAndCreditCardSync = trueString;
         MaxDataToKeep = "25";
         DateExpireLimit = "30";
     }


### PR DESCRIPTION
Add an option so passwords and credit cards are no longer synchronized by default (option enabled by default).

This PR is an adaptation of the following one but for Android : [https://github.com/veler/clipboardzanager/pull/25](https://github.com/veler/clipboardzanager/pull/25)