### PR TITLE
Desktop icon bugfix

### DIFF
--- a/ClipboardZanager/Sources/ClipboardZanager.Core.Desktop/Services/WindowsService.cs
+++ b/ClipboardZanager/Sources/ClipboardZanager.Core.Desktop/Services/WindowsService.cs
@@ -264,7 +264,8 @@ namespace ClipboardZanager.Core.Desktop.Services
             if (icon == null)
             {
                 icon = new BitmapImage();
-                if (applicationIdentifier == Environment.GetFolderPath(Environment.SpecialFolder.Windows) + "\\explorer.exe" && stringBuilder.ToString() == "") // Desktop
+                var test = Environment.GetFolderPath(Environment.SpecialFolder.Windows) + "\\explorer.exe";
+                if (applicationIdentifier.ToLower() == (Environment.GetFolderPath(Environment.SpecialFolder.Windows) + "\\explorer.exe").ToLower() && stringBuilder.ToString() == "") // Desktop
                 {
                     Bitmap bitIcon = Icon.ExtractAssociatedIcon(Environment.GetFolderPath(Environment.SpecialFolder.Windows) + "\\explorer.exe").ToBitmap();
                     using (var memory = new MemoryStream())

--- a/ClipboardZanager/Sources/ClipboardZanager.Core.Desktop/Services/WindowsService.cs
+++ b/ClipboardZanager/Sources/ClipboardZanager.Core.Desktop/Services/WindowsService.cs
@@ -264,7 +264,6 @@ namespace ClipboardZanager.Core.Desktop.Services
             if (icon == null)
             {
                 icon = new BitmapImage();
-                var test = Environment.GetFolderPath(Environment.SpecialFolder.Windows) + "\\explorer.exe";
                 if (applicationIdentifier.ToLower() == (Environment.GetFolderPath(Environment.SpecialFolder.Windows) + "\\explorer.exe").ToLower() && stringBuilder.ToString() == "") // Desktop
                 {
                     Bitmap bitIcon = Icon.ExtractAssociatedIcon(Environment.GetFolderPath(Environment.SpecialFolder.Windows) + "\\explorer.exe").ToBitmap();


### PR DESCRIPTION
Fixed the case when an item is copied from the desktop and the defaulticon is displayed instead of the explorer's one